### PR TITLE
Fix adjustFontFallback option type for Inter font config

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ import { DashboardAnalyticsInitializer } from '@/components/providers/DashboardA
 const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
-  adjustFontFallback: 'size',
+  adjustFontFallback: true,
   fallback: ['system-ui', 'Segoe UI', 'Roboto', 'Helvetica Neue', 'Arial', 'sans-serif'],
   variable: '--font-sans',
 })


### PR DESCRIPTION
## Summary
- replace the invalid string value used for `adjustFontFallback` with the supported boolean flag to satisfy `next/font` typings

## Testing
- not run (tracked `npm run lint` failure persists due to existing parsing errors in Navigation.tsx and navigationItems.ts)


------
https://chatgpt.com/codex/tasks/task_e_68f6964b08e8832b91f2810e6ae0ce75