### PR TITLE
Fix Memory Book navigation route for desktop menu

### DIFF
--- a/src/lib/constants/navigationItems.ts
+++ b/src/lib/constants/navigationItems.ts
@@ -89,7 +89,7 @@ export const DASHBOARD_NAVIGATION_SECTIONS = [
         id: 'summaries',
         label: 'Memory Book',
         icon: BookOpenIcon,
-        href: DASHBOARD_ROUTES.SUMMARIES,
+        href: DASHBOARD_ROUTES.MEMORY_BOOK,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- update the dashboard navigation configuration so the Memory Book item links to the memory book route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6964fd494832b8a1df9a521362bc8